### PR TITLE
fix(Logging): Added [KCP] to all log msgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ docs/.sass-cache
 ehthumbs.db
 Thumbs.db
 /VisRepo.txt
+/packages/NUnit.3.14.0
+/packages.config

--- a/kcp2k/kcp2k.Example/Program.cs
+++ b/kcp2k/kcp2k.Example/Program.cs
@@ -42,18 +42,18 @@ KcpConfig config = new KcpConfig(
 // create server
 KcpServer server = new KcpServer(
     (connectionId) => {},
-    (connectionId, message, channel) => Log.Info($"KCP: OnServerDataReceived({connectionId}, {BitConverter.ToString(message.Array, message.Offset, message.Count)} @ {channel})"),
+    (connectionId, message, channel) => Log.Info($"[KCP] OnServerDataReceived({connectionId}, {BitConverter.ToString(message.Array, message.Offset, message.Count)} @ {channel})"),
     (connectionId) => {},
-    (connectionId, error, reason) => Log.Error($"KCP: OnServerError({connectionId}, {error}, {reason}"),
+    (connectionId, error, reason) => Log.Error($"[KCP] OnServerError({connectionId}, {error}, {reason}"),
     config
 );
 
 // create client
 KcpClient client = new KcpClient(
     () => {},
-    (message, channel) => Log.Info($"KCP: OnClientDataReceived({BitConverter.ToString(message.Array, message.Offset, message.Count)} @ {channel})"),
+    (message, channel) => Log.Info($"[KCP] OnClientDataReceived({BitConverter.ToString(message.Array, message.Offset, message.Count)} @ {channel})"),
     () => {},
-    (error, reason) => Log.Warning($"KCP: OnClientError({error}, {reason}"),
+    (error, reason) => Log.Warning($"[KCP] OnClientError({error}, {reason}"),
     config
 );
 

--- a/kcp2k/kcp2k.Tests/ClientServerTests.cs
+++ b/kcp2k/kcp2k.Tests/ClientServerTests.cs
@@ -93,7 +93,7 @@ namespace kcp2k.Tests
                 (connectionId) => {},
                 ServerOnData,
                 (connectionId) => {},
-                (connectionId, error, reason) => Log.Warning($"connId={connectionId}: {error}, {reason}"),
+                (connectionId, error, reason) => Log.Warning($"[KCP] connId={connectionId}: {error}, {reason}"),
                 config
             );
         }
@@ -105,7 +105,7 @@ namespace kcp2k.Tests
                 () => {},
                 ClientOnData,
                 () => { ++onClientDisconnectCalled; },
-                (error, reason) => Log.Warning($"{error}, {reason}"),
+                (error, reason) => Log.Warning($"[KCP] {error}, {reason}"),
                 config
             );
         }
@@ -319,7 +319,7 @@ namespace kcp2k.Tests
             byte[] message = new byte[KcpPeer.ReliableMaxMessageSize(config.Mtu, config.ReceiveWindowSize)];
             for (int i = 0; i < message.Length; ++i)
                 message[i] = (byte)(i & 0xFF);
-            Log.Info($"Sending {message.Length} bytes = {message.Length / 1024} KB message");
+            Log.Info($"[KCP] Sending {message.Length} bytes = {message.Length / 1024} KB message");
             SendClientToServerBlocking(new ArraySegment<byte>(message), KcpChannel.Reliable);
             UpdateSeveralTimes(5);
             Assert.That(serverReceived.Count, Is.EqualTo(1));
@@ -337,7 +337,7 @@ namespace kcp2k.Tests
             byte[] message = new byte[KcpPeer.UnreliableMaxMessageSize(config.Mtu)];
             for (int i = 0; i < message.Length; ++i)
                 message[i] = (byte)(i & 0xFF);
-            Log.Info($"Sending {message.Length} bytes = {message.Length / 1024} KB message");
+            Log.Info($"[KCP] Sending {message.Length} bytes = {message.Length / 1024} KB message");
             SendClientToServerBlocking(new ArraySegment<byte>(message), KcpChannel.Unreliable);
             Assert.That(serverReceived.Count, Is.EqualTo(1));
             Assert.That(serverReceived[0].data.SequenceEqual(message), Is.True);
@@ -360,7 +360,7 @@ namespace kcp2k.Tests
             byte[] message = new byte[Kcp.MTU_DEF - 5];
             for (int i = 0; i < message.Length; ++i)
                 message[i] = (byte)(i & 0xFF);
-            Log.Info($"Sending {message.Length} bytes = {message.Length / 1024} KB message");
+            Log.Info($"[KCP] Sending {message.Length} bytes = {message.Length / 1024} KB message");
             SendClientToServerBlocking(new ArraySegment<byte>(message), channel);
             Assert.That(serverReceived.Count, Is.EqualTo(1));
             Assert.That(serverReceived[0].data.SequenceEqual(message), Is.True);
@@ -877,7 +877,7 @@ namespace kcp2k.Tests
 
             // sleep for half a timeout
             int firstSleep = config.Timeout / 2;
-            Log.Info($"sleeping for {firstSleep} ms...");
+            Log.Info($"[KCP] sleeping for {firstSleep} ms...");
             Thread.Sleep(firstSleep);
 
             // send one reliable message to both ends
@@ -891,7 +891,7 @@ namespace kcp2k.Tests
             // sleep for half a timeout again.
             // use exactly the remainder instead of '/2' so nothing gets lost
             int lastSleep = config.Timeout - firstSleep + 1;
-            Log.Info($"sleeping for {lastSleep} ms...");
+            Log.Info($"[KCP] sleeping for {lastSleep} ms...");
             Thread.Sleep(lastSleep);
 
             // should still be connected

--- a/kcp2k/kcp2k.Tests/MultiClientServerTests.cs
+++ b/kcp2k/kcp2k.Tests/MultiClientServerTests.cs
@@ -91,7 +91,7 @@ namespace kcp2k.Tests
                 (connectionId) => {},
                 ServerOnData,
                 (connectionId) => {},
-                (connectionId, error, reason) => Log.Warning($"connId={connectionId}: {error}, {reason}"),
+                (connectionId, error, reason) => Log.Warning($"[KCP] connId={connectionId}: {error}, {reason}"),
                 config
             );
         }
@@ -103,14 +103,14 @@ namespace kcp2k.Tests
                 () => {},
                 ClientOnDataA,
                 () => {},
-                (error, reason) => Log.Warning($"A: {error}, {reason}"),
+                (error, reason) => Log.Warning($"[KCP] A: {error}, {reason}"),
                 config
             );
             clientB = new KcpClient(
                 () => {},
                 ClientOnDataB,
                 () => {},
-                (error, reason) => Log.Warning($"B: {error}, {reason}"),
+                (error, reason) => Log.Warning($"[KCP] B: {error}, {reason}"),
                 config
             );
         }

--- a/kcp2k/kcp2k/highlevel/Common.cs
+++ b/kcp2k/kcp2k/highlevel/Common.cs
@@ -18,7 +18,7 @@ namespace kcp2k
             }
             catch (SocketException exception)
             {
-                Log.Info($"Failed to resolve host: {hostname} reason: {exception}");
+                Log.Info($"[KCP] Failed to resolve host: {hostname} reason: {exception}");
                 addresses = null;
                 return false;
             }
@@ -41,11 +41,11 @@ namespace kcp2k
             }
             catch (SocketException)
             {
-                Log.Warning($"Kcp: failed to set Socket RecvBufSize = {recvBufferSize} SendBufSize = {sendBufferSize}");
+                Log.Warning($"[KCP] failed to set Socket RecvBufSize = {recvBufferSize} SendBufSize = {sendBufferSize}");
             }
 
 
-            Log.Info($"Kcp: RecvBuf = {initialReceive}=>{socket.ReceiveBufferSize} ({socket.ReceiveBufferSize/initialReceive}x) SendBuf = {initialSend}=>{socket.SendBufferSize} ({socket.SendBufferSize/initialSend}x)");
+            Log.Info($"[KCP] RecvBuf = {initialReceive}=>{socket.ReceiveBufferSize} ({socket.ReceiveBufferSize/initialReceive}x) SendBuf = {initialSend}=>{socket.SendBufferSize} ({socket.SendBufferSize/initialSend}x)");
         }
 
         // generate a connection hash from IP+Port.

--- a/kcp2k/kcp2k/highlevel/KcpClient.cs
+++ b/kcp2k/kcp2k/highlevel/KcpClient.cs
@@ -65,7 +65,7 @@ namespace kcp2k
         // some callbacks need to wrapped with some extra logic
         protected override void OnAuthenticated()
         {
-            Log.Info($"KcpClient: OnConnected");
+            Log.Info($"[KCP] Client: OnConnected");
             connected = true;
             OnConnectedCallback();
         }
@@ -78,7 +78,7 @@ namespace kcp2k
 
         protected override void OnDisconnected()
         {
-            Log.Info($"KcpClient: OnDisconnected");
+            Log.Info($"[KCP] Client: OnDisconnected");
             connected = false;
             socket?.Close();
             socket = null;
@@ -92,7 +92,7 @@ namespace kcp2k
         {
             if (connected)
             {
-                Log.Warning("KcpClient: already connected!");
+                Log.Warning("[KCP] Client: already connected!");
                 return;
             }
 
@@ -110,7 +110,7 @@ namespace kcp2k
             // client doesn't need secure cookie.
             Reset(config);
 
-            Log.Info($"KcpClient: connect to {address}:{port}");
+            Log.Info($"[KCP] Client: connect to {address}:{port}");
 
             // create socket
             remoteEndPoint = new IPEndPoint(addresses[0], port);
@@ -156,7 +156,7 @@ namespace kcp2k
                 // at least log a message for easier debugging.
                 // for example, his can happen when connecting without a server.
                 // see test: ConnectWithoutServer().
-                Log.Info($"KcpClient: looks like the other end has closed the connection. This is fine: {e}");
+                Log.Info($"[KCP] Client: looks like the other end has closed the connection. This is fine: {e}");
                 base.Disconnect();
                 return false;
             }
@@ -172,7 +172,7 @@ namespace kcp2k
             }
             catch (SocketException e)
             {
-                Log.Error($"KcpClient: Send failed: {e}");
+                Log.Error($"[KCP] Client: Send failed: {e}");
             }
         }
 
@@ -180,7 +180,7 @@ namespace kcp2k
         {
             if (!connected)
             {
-                Log.Warning("KcpClient: can't send because not connected!");
+                Log.Warning("[KCP] Client: can't send because not connected!");
                 return;
             }
 
@@ -217,17 +217,17 @@ namespace kcp2k
             Utils.Decode32U(segment.Array, segment.Offset + 1, out uint messageCookie);
             if (messageCookie == 0)
             {
-                Log.Error($"KcpClient: received message with cookie=0, this should never happen. Server should always include the security cookie.");
+                Log.Error($"[KCP] Client: received message with cookie=0, this should never happen. Server should always include the security cookie.");
             }
 
             if (cookie == 0)
             {
                 cookie = messageCookie;
-                Log.Info($"KcpClient: received initial cookie: {cookie}");
+                Log.Info($"[KCP] Client: received initial cookie: {cookie}");
             }
             else if (cookie != messageCookie)
             {
-                Log.Warning($"KcpClient: dropping message with mismatching cookie: {messageCookie} expected: {cookie}.");
+                Log.Warning($"[KCP] Client: dropping message with mismatching cookie: {messageCookie} expected: {cookie}.");
                 return;
             }
 
@@ -251,7 +251,7 @@ namespace kcp2k
                     // invalid channel indicates random internet noise.
                     // servers may receive random UDP data.
                     // just ignore it, but log for easier debugging.
-                    Log.Warning($"KcpClient: invalid channel header: {channel}, likely internet noise");
+                    Log.Warning($"[KCP] Client: invalid channel header: {channel}, likely internet noise");
                     break;
                 }
             }

--- a/kcp2k/kcp2k/highlevel/KcpPeer.cs
+++ b/kcp2k/kcp2k/highlevel/KcpPeer.cs
@@ -153,7 +153,7 @@ namespace kcp2k
             // set the cookie after resetting state so it's not overwritten again.
             // with log message for debugging in case of cookie issues.
             this.cookie = cookie;
-            Log.Info($"{GetType()}: created with cookie={cookie}");
+            Log.Info($"[KCP] {GetType()}: created with cookie={cookie}");
 
             // create mtu sized send buffer
             rawSendBuffer = new byte[config.Mtu];
@@ -246,7 +246,7 @@ namespace kcp2k
             if (time >= lastPingTime + PING_INTERVAL)
             {
                 // ping again and reset time
-                //Log.Debug("KCP: sending ping...");
+                //Log.Debug("[KCP] sending ping...");
                 SendPing();
                 lastPingTime = time;
             }
@@ -340,7 +340,7 @@ namespace kcp2k
                         // it proves that the other end speaks our protocol.
 
                         // log with previously parsed cookie
-                        Log.Info($"{GetType()}: received hello with cookie={cookie}");
+                        Log.Info($"[KCP] {GetType()}: received hello with cookie={cookie}");
                         state = KcpState.Authenticated;
                         OnAuthenticated();
                         break;
@@ -356,7 +356,7 @@ namespace kcp2k
                         // everything else is not allowed during handshake!
                         // pass error to user callback. no need to log it manually.
                         // GetType() shows Server/ClientConn instead of just Connection.
-                        OnError(ErrorCode.InvalidReceive, $"{GetType()}: received invalid header {header} while Connected. Disconnecting the connection.");
+                        OnError(ErrorCode.InvalidReceive, $"[KCP] {GetType()}: received invalid header {header} while Connected. Disconnecting the connection.");
                         Disconnect();
                         break;
                     }
@@ -413,7 +413,7 @@ namespace kcp2k
                     {
                         // disconnect might happen
                         // GetType() shows Server/ClientConn instead of just Connection.
-                        Log.Info($"{GetType()}: received disconnect message");
+                        Log.Info($"[KCP] {GetType()}: received disconnect message");
                         Disconnect();
                         break;
                     }
@@ -529,7 +529,7 @@ namespace kcp2k
             if (input != 0)
             {
                 // GetType() shows Server/ClientConn instead of just Connection.
-                Log.Warning($"{GetType()}: Input failed with error={input} for buffer with length={message.Count - 1}");
+                Log.Warning($"[KCP] {GetType()}: Input failed with error={input} for buffer with length={message.Count - 1}");
             }
         }
 
@@ -638,7 +638,7 @@ namespace kcp2k
             {
                 // otherwise content is larger than MaxMessageSize. let user know!
                 // GetType() shows Server/ClientConn instead of just Connection.
-                Log.Error($"{GetType()}: Failed to send unreliable message of size {message.Count} because it's larger than UnreliableMaxMessageSize={unreliableMax}");
+                Log.Error($"[KCP] {GetType()}: Failed to send unreliable message of size {message.Count} because it's larger than UnreliableMaxMessageSize={unreliableMax}");
                 return;
             }
 
@@ -671,7 +671,7 @@ namespace kcp2k
             // cookie is automatically included in all messages.
 
             // GetType() shows Server/ClientConn instead of just Connection.
-            Log.Info($"{GetType()}: sending handshake to other end with cookie={cookie}");
+            Log.Info($"[KCP] {GetType()}: sending handshake to other end with cookie={cookie}");
             SendReliable(KcpHeader.Hello, default);
         }
 
@@ -738,7 +738,7 @@ namespace kcp2k
 
             // set as Disconnected, call event
             // GetType() shows Server/ClientConn instead of just Connection.
-            Log.Info($"{GetType()}: Disconnected.");
+            Log.Info($"[KCP] {GetType()}: Disconnected.");
             state = KcpState.Disconnected;
             OnDisconnected();
         }

--- a/kcp2k/kcp2k/highlevel/KcpServer.cs
+++ b/kcp2k/kcp2k/highlevel/KcpServer.cs
@@ -84,7 +84,7 @@ namespace kcp2k
                 }
                 catch (NotSupportedException e)
                 {
-                    Log.Warning($"Failed to set Dual Mode, continuing with IPv6 without Dual Mode. Error: {e}");
+                    Log.Warning($"[KCP] Failed to set Dual Mode, continuing with IPv6 without Dual Mode. Error: {e}");
                 }
 
                 // for windows sockets, there's a rare issue where when using
@@ -151,7 +151,7 @@ namespace kcp2k
             // only start once
             if (socket != null)
             {
-                Log.Warning("KcpServer: already started!");
+                Log.Warning("[KCP] Server: already started!");
                 return;
             }
 
@@ -219,7 +219,7 @@ namespace kcp2k
                 // the other end closing the connection is not an 'error'.
                 // but connections should never just end silently.
                 // at least log a message for easier debugging.
-                Log.Info($"KcpServer: ReceiveFrom failed: {e}");
+                Log.Info($"[KCP] Server: ReceiveFrom failed: {e}");
             }
 
             return false;
@@ -233,7 +233,7 @@ namespace kcp2k
             // get the connection's endpoint
             if (!connections.TryGetValue(connectionId, out KcpServerConnection connection))
             {
-                Log.Warning($"KcpServer: RawSend invalid connectionId={connectionId}");
+                Log.Warning($"[KCP] Server: RawSend invalid connectionId={connectionId}");
                 return;
             }
 
@@ -243,7 +243,7 @@ namespace kcp2k
             }
             catch (SocketException e)
             {
-                Log.Error($"KcpServer: SendTo failed: {e}");
+                Log.Error($"[KCP] Server: SendTo failed: {e}");
             }
         }
 
@@ -274,7 +274,7 @@ namespace kcp2k
             {
                 // add to connections dict after being authenticated.
                 connections.Add(connectionId, conn);
-                Log.Info($"KcpServer: added connection({connectionId})");
+                Log.Info($"[KCP] Server: added connection({connectionId})");
 
                 // setup Data + Disconnected events only AFTER the
                 // handshake. we don't want to fire OnServerDisconnected
@@ -284,7 +284,7 @@ namespace kcp2k
                 // setup data event
 
                 // finally, call mirror OnConnected event
-                Log.Info($"KcpServer: OnConnected({connectionId})");
+                Log.Info($"[KCP] Server: OnConnected({connectionId})");
                 OnConnected(connectionId);
             }
 
@@ -296,7 +296,7 @@ namespace kcp2k
                 connectionsToRemove.Add(connectionId);
 
                 // call mirror event
-                Log.Info($"KcpServer: OnDisconnected({connectionId})");
+                Log.Info($"[KCP] Server: OnDisconnected({connectionId})");
                 OnDisconnected(connectionId);
             }
         }
@@ -305,7 +305,7 @@ namespace kcp2k
         // best to call this as long as there is more data to receive.
         void ProcessMessage(ArraySegment<byte> segment, int connectionId)
         {
-            //Log.Info($"KCP: server raw recv {msgLength} bytes = {BitConverter.ToString(buffer, 0, msgLength)}");
+            //Log.Info($"[KCP] server raw recv {msgLength} bytes = {BitConverter.ToString(buffer, 0, msgLength)}");
 
             // is this a new connection?
             if (!connections.TryGetValue(connectionId, out KcpServerConnection connection))

--- a/kcp2k/kcp2k/highlevel/KcpServerConnection.cs
+++ b/kcp2k/kcp2k/highlevel/KcpServerConnection.cs
@@ -90,7 +90,7 @@ namespace kcp2k
             {
                 if (messageCookie != cookie)
                 {
-                    Log.Warning($"KcpServerConnection: dropped message with invalid cookie: {messageCookie} expected: {cookie} state: {state}");
+                    Log.Warning($"[KCP] ServerConnection: dropped message with invalid cookie: {messageCookie} expected: {cookie} state: {state}");
                     return;
                 }
             }
@@ -115,7 +115,7 @@ namespace kcp2k
                     // invalid channel indicates random internet noise.
                     // servers may receive random UDP data.
                     // just ignore it, but log for easier debugging.
-                    Log.Warning($"KcpServerConnection: invalid channel header: {channel}, likely internet noise");
+                    Log.Warning($"[KCP] ServerConnection: invalid channel header: {channel}, likely internet noise");
                     break;
                 }
             }


### PR DESCRIPTION
Mostly for the benefit of Multiplexor but also clearly indicates the source of log entries in consuming apps, e.g. Unity.